### PR TITLE
Update for 53.2 update

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -3,8 +3,8 @@ import * as R from "ramda";
 
 const generate = () => {
   const document = sketch.getSelectedDocument();
-  const layerStyles = document.getSharedLayerStyles();
-  const textStyles = document.getSharedTextStyles();
+  const layerStyles = document.sharedLayerStyles;
+  const textStyles = document.sharedTextStyles;
   const selection = document.selectedLayers;
   const layers = selection.layers;
   const count = { created: 0, updated: 0 };


### PR DESCRIPTION
Changed the document.getShared<type>Styles() to fix the plugin for 53.2 update. These have been deprecated and replaced with Array elements document.shared<Type>Styles.